### PR TITLE
Fix incorrect minimum node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "main": "src/index.js",
   "engines": {
-    "node": ">=8.9.0"
+    "node": ">=11.0.0"
   },
   "scripts": {
     "test": "eslint src/ --max-warnings=0"


### PR DESCRIPTION
Array#flatMap requires v11.0.0 according to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap#Browser_compatibility