### PR TITLE
Add option to override path to colors in config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ mix.palette(options);
 |     `tailwind`    	|  `{Object}` 	|              `{ ... }`             	| Set Tailwind options. (See below)                                                                    	|
 | `tailwind.config` 	|  `{String}` 	|      `'./tailwind.config.js'`      	| Path to the Tailwind configuration file relative to the project root path.                           	|
 | `tailwind.shades` 	| `{Boolean}` 	|               `false`              	| While set to `true`, every color shade (`100-900`) will be generated. Otherwise, only `500` is used. 	|
-| `tailwind.path` 	| `{String}` 	|               `colors`              	| Path to Tailwind config values for palette colors in dot notation. Uses Tailwind's color palette `theme('colors')` per default. 	|
+| `tailwind.path` 	| `{String}` 	|               `'colors'`              	| Path to Tailwind config values for palette colors in dot notation. Uses Tailwind's color palette `theme('colors')` per default. 	|
 |       `sass`      	|  `{Object}` 	|              `{ ... }`             	| Set Sass options. (See below)                                                                        	|
 |    `sass.path`    	|  `{String}` 	| `'resources/assets/styles/config'` 	| Path to Sass variable files relative to the project root path.                                       	|
 |    `sass.files`   	|  `{Array}`  	|        `['variables.scss']`        	| An array of files to search for the defined Sass variables.                                          	|

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ module.exports = {
       pretty: false,
       tailwind: {
         config: './tailwind.config.js',
-        shades: false
+        shades: false,
+        path: 'colors'
       },
       sass: {
         path: 'resources/assets/styles/config',
@@ -138,6 +139,7 @@ mix.palette(options);
 |     `tailwind`    	|  `{Object}` 	|              `{ ... }`             	| Set Tailwind options. (See below)                                                                    	|
 | `tailwind.config` 	|  `{String}` 	|      `'./tailwind.config.js'`      	| Path to the Tailwind configuration file relative to the project root path.                           	|
 | `tailwind.shades` 	| `{Boolean}` 	|               `false`              	| While set to `true`, every color shade (`100-900`) will be generated. Otherwise, only `500` is used. 	|
+| `tailwind.path` 	| `{String}` 	|               `colors`              	| Path to Tailwind config values for palette colors in dot notation. Uses Tailwind's color palette `theme('colors')` per default. 	|
 |       `sass`      	|  `{Object}` 	|              `{ ... }`             	| Set Sass options. (See below)                                                                        	|
 |    `sass.path`    	|  `{String}` 	| `'resources/assets/styles/config'` 	| Path to Sass variable files relative to the project root path.                                       	|
 |    `sass.files`   	|  `{Array}`  	|        `['variables.scss']`        	| An array of files to search for the defined Sass variables.                                          	|

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,8 @@ class PaletteWebpackPlugin {
       pretty: false,
       tailwind: {
         config: './tailwind.config.js',
-        shades: false
+        shades: false,
+        path: 'colors'
       },
       sass: {
         path: 'resources/assets/styles/config',
@@ -135,9 +136,15 @@ class PaletteWebpackPlugin {
       return [];
     }
 
-    this.tailwind = require('tailwindcss/resolveConfig')(
+    const config = require('tailwindcss/resolveConfig')(
       require(path.resolve(this.options.tailwind.config))
-    ).theme.colors;
+    );
+
+    this.tailwind = _.get(
+      config,
+      `theme.${this.options.tailwind.path || 'colors'}`,
+      {}
+    );
 
     return Object.keys(this.tailwind)
       .flatMap(key => {
@@ -248,7 +255,7 @@ class PaletteWebpackPlugin {
    */
   maybeGrayscale(color) {
     const { h, s, v } = d3Hsv(color);
-    
+
     /**
      * HSV is a cylinder where the central vertical axis comprises
      * the neutral, achromatic, or gray colors.


### PR DESCRIPTION
To be able to declare colors independently of the Tailwind´s overall colors and specific for the WordPress Block Editor, this PR adds an option to specify the path in the tailwind config object, with the `theme` key as root.

For example you can declare the palettes´ colors in:

```js
module.exports = {
  theme: {
    palette: {
      colors: {
        indigo: '#667eea',
      }
    }
  }
}
```

and set the option to:
```js
{
  /* ... */
  tailwind: {
    config: './tailwind.config.js',
    shades: false,
    path: 'palette.colors'
  }
  /* ... */
}
```