### PR TITLE
Missing slash borked the tailwind.shades table row

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ mix.palette(options);
 |      `pretty`     	| `{Boolean}` 	|               `false`              	| Use pretty formatting when writing the JSON file.                                                    	|
 |     `tailwind`    	|  `{Object}` 	|              `{ ... }`             	| Set Tailwind options. (See below)                                                                    	|
 | `tailwind.config` 	|  `{String}` 	|      `'./tailwind.config.js'`      	| Path to the Tailwind configuration file relative to the project root path.                           	|
-| `tailwind.shades` 	| `{Array|Boolean}` 	|               `false`              	| While set to `true`, every color shade (`100-900`) will be generated. Optionally, you may pass an array of shades. When set to `false`, only `500` is used. 	|
+| `tailwind.shades` 	| `{Array\|Boolean}` 	|               `false`              	| While set to `true`, every color shade (`100-900`) will be generated. Optionally, you may pass an array of shades. When set to `false`, only `500` is used. 	|
 | `tailwind.path` 	| `{String}` 	|               `'colors'`              	| Path to Tailwind config values for palette colors in dot notation. Uses Tailwind's color palette `theme('colors')` per default. 	|
 |       `sass`      	|  `{Object}` 	|              `{ ... }`             	| Set Sass options. (See below)                                                                        	|
 |    `sass.path`    	|  `{String}` 	| `'resources/assets/styles/config'` 	| Path to Sass variable files relative to the project root path.                                       	|


### PR DESCRIPTION
Also, being able to pass an array to shades is 🔥.