### PR TITLE
Allow descriptive Tailwind shades, including DEFAULT

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -200,11 +200,11 @@ class PaletteWebpackPlugin {
 
     return {
       name: isNaN(value)
-        ? this.title(value)
+        ? this.title(key, value)
         : this.options.tailwind.shades
         ? this.title(key, value)
         : this.title(key),
-      slug: `${key}-${value}`,
+      slug: `${key}${value === 'DEFAULT' ? '' : `-${value}`}`,
       color: this.tailwind[key][value]
     };
   }


### PR DESCRIPTION
Descriptive shades use the value solely as the name without the key. For example `midnight.light` is named `Light` and any other colors with the same shade are dropped in `palette.json`.

When using Tailwind's DEFAULT shade, the slug contains `-DEFAULT`, which is inconsistent with Tailwind's usage.

**tailwind.config.js**
```js
...
colors: {
  midnight: {
    DEFAULT: '#21213c', // DEFAULT is used by Tailwind to define .text-midnight
    light: '#30304b',
  },
  grass: {
    DEFAULT: '#8cc64b',
    light: '#9bd55a',
  },
},
...
```

**Before:**
```json
[
  { "name": "Default", "slug": "midnight-DEFAULT", "color": "#21213c" },
  { "name": "Light", "slug": "midnight-light", "color": "#30304b" }
]
```

**After:**
```json
[
  { "name": "Grass (Default)", "slug": "grass", "color": "#8cc64b" },
  { "name": "Grass (Light)", "slug": "grass-light", "color": "#9bd55a" },
  { "name": "Midnight (Default)", "slug": "midnight", "color": "#21213c" },
  { "name": "Midnight (Light)", "slug": "midnight-light", "color": "#30304b" }
]
```